### PR TITLE
Formatting dollar amounts with toLocaleString

### DIFF
--- a/src/components/Difference/index.js
+++ b/src/components/Difference/index.js
@@ -48,7 +48,7 @@ function Difference({ processorValues }) {
         do {
           const firstPrice = firstProcessor.finalValue;
           const secondPrice = secondProcessor.finalValue;
-          const difference = (firstPrice - secondPrice).toFixed(2);
+          const difference = (firstPrice - secondPrice).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
           <Fragment>
             <A.Space size={3} />
             <S.Value>$ {difference}</S.Value>

--- a/src/components/ProcessorCard/index.js
+++ b/src/components/ProcessorCard/index.js
@@ -9,7 +9,7 @@ function ProcessorCard({ name, finalValue }) {
     <S.ProcessorCard>
       <S.Name>{name}</S.Name>
       <A.Space size={2} />
-      <S.Value>$ {finalValue.toFixed(2)}</S.Value>
+      <S.Value>$ {finalValue.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</S.Value>
     </S.ProcessorCard>
   );
 }


### PR DESCRIPTION
As dollar amounts became larger, it could be difficult to read. I switched from toFixed to use [toLocaleString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString). The two params are the locale and some options. Setting the locale to undefined uses the locale defined on the OS of a user. Second, the options say to include two decimal points always by setting both minimumFractionDigits and maximumFractionDigits to 2.

It will add commas through the number to make it easier to read.

This is how the app shows up on my computer now with the en_US locale:

![screen shot 2018-10-28 at 11 45 10 am](https://user-images.githubusercontent.com/3685876/47618233-13b7b400-daa7-11e8-906e-d75f2ade43b5.png)